### PR TITLE
Big Windows Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ VirtCI adheres to [Semantic Versioning](https://semver.org/).
   - Useful for persisting modifications in a VM without having to change the base.
 - Rename a VM image locally with `virtci edit <image> --rename <new_name>`.
   - Crash safe, even for SIGKILL.
+- Support running UEFI VMs directly on Windows hosts, not just inside WSL2.
+  - Only used if WSL2 KVM acceleration isn't available, and disables WHPX acceleration, so uses much slower TCG emulation.
+  - Useful for running VMs inside of windows VMs.
+
+### Fixed
+
+- Fixed issue where Windows Host couldn't access VM-inside-WSL2 over SSH with various WSL2 configurations.
+- Fixed stdout/stderr formatting in some terminals during workflow runs.
+- Fixed `virtci active` not correctly tracking active workflows on Windows.
 
 ## Version 0.2.0 - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ VirtCI adheres to [Semantic Versioning](https://semver.org/).
 - Fixed Windows being unable to run TPM or UEFI enabled VMs.
   - Now, TPM or UEFI VMs are ran through WSL2, being invoked on the Windows host.
   - Secure Boot VMs are strictly not supported, and likely will never be as Windows Hosts and WSL2 lack SMM.
+- Longer timeout for emulated VMs to give them time to connect and boot.
 
 ## Version 0.1.0 - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ VirtCI adheres to [Semantic Versioning](https://semver.org/).
 - Fixed issue where Windows Host couldn't access VM-inside-WSL2 over SSH with various WSL2 configurations.
 - Fixed stdout/stderr formatting in some terminals during workflow runs.
 - Fixed `virtci active` not correctly tracking active workflows on Windows.
+- Fixed Windows not finding system RISC-V64 UEFI files.
+- Fixed issue where VirtCI would take a while to find a valid QEMU TCP port due to WinNAT/Hyper-V reservation table.
+- Fixed issue where workflow run setting the VM offline did not work when running on a Windows host through WSL2.
 
 ## Version 0.2.0 - 2026-05-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "argh",
+ "aws-lc-rs",
  "cc",
  "colored",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde_with = "3.17.0"
 russh = { version = "0.60.0", default-features = false, features = [
   "aws-lc-rs",
 ] }
+aws-lc-rs = { version = "1", features = ["prebuilt-nasm"] }
 russh-sftp = "2.0"
 tokio = { version = "1", features = [
   "rt",

--- a/src/backend/exec.rs
+++ b/src/backend/exec.rs
@@ -20,13 +20,23 @@ use anyhow::Context;
 use crate::vm_image::HostExecTarget;
 
 /// How a spawned child's standard streams are wired.
+///
+/// Every variant except [`ChildIo::Interactive`] detaches the child from virtci's console on
+/// Windows (`CREATE_NO_WINDOW`). This matters because the child can be `wsl.exe`, which
+/// reconfigures whatever console it inherits into VT/raw mode which disables automatic
+/// carriage-return on newline. This can make the print outputs render like a staircase (bad).
+/// A detached child gets its own hidden console instead and leaves virtci's untouched.
 #[derive(Clone, Copy)]
 pub enum ChildIo<'a> {
     /// Discard stdin/stdout/stderr. For background daemons like swtpm.
     Quiet,
-    /// Inherit stdin/stdout (so a guest serial console reaches the terminal) but redirect stderr
-    /// to `path`. For QEMU, so an early launch failure — notably the host-forwarding bind — can
-    /// be read back from the file while the console still works.
+    /// Inherit stdin/stdout (so a guest serial console reaches the terminal) and redirect stderr
+    /// to `path`. For interactive `virtci boot` with `-serial stdio`, the child intentionally
+    /// shares the host console.
+    Interactive(&'a std::path::Path),
+    /// Discard stdin/stdout and redirect stderr to `path`, detached from the console. For
+    /// non-interactive `virtci run` QEMU: an early launch failure (notably the host-forwarding
+    /// bind) can still be read back from the file, without the relay clobbering the console.
     StderrToFile(&'a std::path::Path),
 }
 
@@ -78,6 +88,25 @@ impl Drop for TargetChildProcess {
     }
 }
 
+/// Give a child its own hidden console instead of inheriting virtci's, so it cannot reconfigure
+/// the host console (see [`ChildIo`]). No-op when `detached` is false or off Windows.
+#[cfg_attr(
+    not(target_os = "windows"),
+    allow(unused_variables, clippy::needless_pass_by_ref_mut)
+)]
+fn detach_from_console(cmd: &mut Command, detached: bool) {
+    #[cfg(target_os = "windows")]
+    {
+        if detached {
+            use std::os::windows::process::CommandExt;
+            // CREATE_NO_WINDOW: run the console child with a fresh, invisible console rather than
+            // attaching to virtci's, so wsl.exe/QEMU can't flip our console into VT/raw mode.
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+    }
+}
+
 enum TargetChild {
     Host(Child),
     #[cfg(target_os = "windows")]
@@ -92,12 +121,18 @@ impl TargetChild {
         args: &[String],
         io: ChildIo,
     ) -> anyhow::Result<Self> {
+        let detached = !matches!(io, ChildIo::Interactive(_));
         let (stdin, stdout, stderr) = match io {
             ChildIo::Quiet => (Stdio::null(), Stdio::null(), Stdio::null()),
-            ChildIo::StderrToFile(path) => {
+            ChildIo::Interactive(path) => {
                 let file = std::fs::File::create(path)
                     .with_context(|| format!("failed to create stderr log {}", path.display()))?;
                 (Stdio::inherit(), Stdio::inherit(), Stdio::from(file))
+            }
+            ChildIo::StderrToFile(path) => {
+                let file = std::fs::File::create(path)
+                    .with_context(|| format!("failed to create stderr log {}", path.display()))?;
+                (Stdio::null(), Stdio::null(), Stdio::from(file))
             }
         };
 
@@ -108,6 +143,7 @@ impl TargetChild {
                 cmd.args(["-d", distro.as_str(), "--", program]);
                 cmd.args(args);
                 cmd.stdin(stdin).stdout(stdout).stderr(stderr);
+                detach_from_console(&mut cmd, detached);
                 let relay = cmd
                     .spawn()
                     .with_context(|| format!("failed to spawn `{program}` via WSL2"))?;
@@ -121,6 +157,7 @@ impl TargetChild {
                 let _ = marker;
                 let mut cmd = Command::new(program);
                 cmd.args(args).stdin(stdin).stdout(stdout).stderr(stderr);
+                detach_from_console(&mut cmd, detached);
                 let child = cmd
                     .spawn()
                     .with_context(|| format!("failed to spawn `{program}`"))?;

--- a/src/backend/qemu/backend.rs
+++ b/src/backend/qemu/backend.rs
@@ -37,6 +37,10 @@ pub struct QemuBackend {
     /// and routed to stdio when `!graphics`, or to this file when `graphics`.
     pub serial_log: Option<TargetPath>,
     pub exec_target: HostExecTarget,
+    /// The host-reachable IP the forwarded SSH port lives on. `127.0.0.1` for native targets;
+    /// for a WSL2 target it's the distro's NAT IP, since QEMU's `hostfwd` binds inside WSL2 and
+    /// `127.0.0.1` only works there if WSL2 localhost forwarding is enabled.
+    pub ssh_ip: String,
     pub host_temp_dir: PathBuf,
     pub exec_target_temp_dir: TargetPath,
 
@@ -79,20 +83,19 @@ impl QemuBackend {
         let exec_target: HostExecTarget = {
             #[cfg(target_os = "windows")]
             {
-                let qemu = base_image.backend.as_qemu().expect("Expected QEMU config");
-                if qemu.requires_wsl2() {
-                    if let Some(wsl_paths) = &paths.wsl {
-                        HostExecTarget::WSL2(wsl_paths.distro.clone())
-                    } else {
-                        let reason = if qemu.tpm { "a TPM" } else { "UEFI firmware" };
+                // Where an image is stored is where it should run.
+                if let Some(distro) = &base_image.wsl_distro {
+                    HostExecTarget::WSL2(distro.clone())
+                } else {
+                    let qemu = base_image.backend.as_qemu().expect("Expected QEMU config");
+                    if qemu.tpm {
                         anyhow::bail!(
-                            "Image '{}' needs {reason}, which on Windows requires KVM via WSL2 \
-                             (native QEMU/WHPX cannot run TPM or UEFI guests), but no WSL2 distro \
-                             is configured.",
+                            "Image '{}' needs a TPM, which on Windows requires WSL2, but it is \
+                             stored on the Windows host. Re-import it with a WSL2 distro \
+                             configured.",
                             base_image.name
                         )
                     }
-                } else {
                     HostExecTarget::WindowsNative
                 }
             }
@@ -105,6 +108,24 @@ impl QemuBackend {
                 HostExecTarget::Linux
             }
         };
+
+        #[cfg(target_os = "windows")]
+        let ssh_ip: String = match &exec_target {
+            HostExecTarget::WSL2(distro) => match crate::backend::qemu::wsl_distro_ip(distro) {
+                Ok(ip) => ip,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not resolve the WSL2 distro IP ({e}); falling back to \
+                         127.0.0.1. SSH from the Windows host will fail unless WSL2 localhost \
+                         forwarding is enabled."
+                    );
+                    "127.0.0.1".to_string()
+                }
+            },
+            _ => "127.0.0.1".to_string(),
+        };
+        #[cfg(not(target_os = "windows"))]
+        let ssh_ip: String = "127.0.0.1".to_string();
 
         let setup = setup_run(
             &name,
@@ -129,6 +150,7 @@ impl QemuBackend {
             graphics,
             serial_log: setup.serial_log,
             exec_target,
+            ssh_ip,
             host_temp_dir,
             exec_target_temp_dir,
             image_lock: setup.image_lock,
@@ -263,6 +285,12 @@ impl VmBackend for QemuBackend {
             .host_temp_dir
             .join(format!("{}-qemu.stderr", self.run_marker()));
 
+        let qemu_io = if self.serial_log.is_some() && !self.graphics {
+            exec::ChildIo::Interactive(&stderr_log)
+        } else {
+            exec::ChildIo::StderrToFile(&stderr_log)
+        };
+
         let qemu = loop {
             let cmd = super::binaries::build_qemu_args(self)?;
 
@@ -277,7 +305,7 @@ impl VmBackend for QemuBackend {
                 &self.run_marker(),
                 &cmd.program,
                 &cmd.arguments,
-                exec::ChildIo::StderrToFile(&stderr_log),
+                qemu_io,
             )
             .context("Failed to spawn QEMU")?;
             self.orphans.add_child_process(&qemu);
@@ -325,7 +353,7 @@ impl VmBackend for QemuBackend {
 
     fn ssh_target(&self) -> crate::vm_image::SshTarget {
         crate::vm_image::SshTarget {
-            ip: "127.0.0.1".to_string(),
+            ip: self.ssh_ip.clone(),
             port: self
                 .host_port
                 .as_ref()

--- a/src/backend/qemu/backend.rs
+++ b/src/backend/qemu/backend.rs
@@ -294,7 +294,10 @@ impl VmBackend for QemuBackend {
         let qemu = loop {
             let cmd = super::binaries::build_qemu_args(self)?;
 
-            eprintln!("QEMU launch command:");
+            eprintln!(
+                "QEMU launch command... Attempting to bind QEMU to TCP port [{}]:",
+                self.host_port.as_ref().expect("what").port
+            );
             eprintln!(
                 "{}",
                 super::binaries::format_launch_command(&self.exec_target, &cmd)
@@ -365,6 +368,35 @@ impl VmBackend for QemuBackend {
 
     fn os(&self) -> crate::vm_image::GuestOs {
         self.base_image.os
+    }
+
+    fn is_offline(&self) -> bool {
+        self.start_config.offline.unwrap_or(false)
+    }
+
+    fn offline_enforce_cmd(&self) -> Option<&'static str> {
+        // slirp's `restrict=yes` breaks host->guest SSH on WSL2 (see `build_qemu_args`),
+        // so offline is enforced in-guest by deleting the default route.
+        // The tart backend does this. The subnet route remains, so SSH via the slirp gateway keeps
+        // working. Route tables are in-memory and reset on VM restart, so toggling works.
+        // Absolutely not as good as the restrict.
+        if !matches!(self.exec_target, HostExecTarget::WSL2(_)) {
+            return None;
+        }
+        match self.base_image.os {
+            crate::vm_image::GuestOs::Windows => Some(
+                "$peer = ($env:SSH_CONNECTION -split ' ')[0]; \
+                 route add $peer mask 255.255.255.255 10.0.2.2 2>&1 | Out-Null; \
+                 route delete 0.0.0.0 | Out-Null; \
+                 if ($LASTEXITCODE -ne 0) { exit 1 }; \
+                 route delete ::/0 2>&1 | Out-Null; exit 0",
+            ),
+            _ => Some(
+                "peer=\"${SSH_CONNECTION%% *}\" && \
+                 { sudo ip route add \"$peer/32\" via 10.0.2.2 2>/dev/null || true; } && \
+                 sudo ip route del default && (sudo ip -6 route del default || true)",
+            ),
+        }
     }
 
     fn run_name(&self) -> String {

--- a/src/backend/qemu/binaries.rs
+++ b/src/backend/qemu/binaries.rs
@@ -467,7 +467,9 @@ pub fn build_qemu_args(backend: &super::backend::QemuBackend) -> anyhow::Result<
         .port;
     let inside = backend.inside_vm_port;
     let offline = backend.start_config.offline.unwrap_or(false);
-    let netdev = if offline {
+    // slirp's `restrict=yes` is unusable on WSL2 from a Windows host.
+    let use_restrict = offline && !matches!(backend.exec_target, HostExecTarget::WSL2(_));
+    let netdev = if use_restrict {
         format!("user,id=net0,restrict=yes,hostfwd=tcp::{host_port}-:{inside}")
     } else {
         format!("user,id=net0,hostfwd=tcp::{host_port}-:{inside}")

--- a/src/backend/qemu/binaries.rs
+++ b/src/backend/qemu/binaries.rs
@@ -449,7 +449,14 @@ pub fn build_qemu_args(backend: &super::backend::QemuBackend) -> anyhow::Result<
             }
         }
         HostExecTarget::MacOS => push_arg(&mut args, "-accel", "hvf"),
-        HostExecTarget::WindowsNative => push_arg(&mut args, "-accel", "whpx"),
+        HostExecTarget::WindowsNative => {
+            // WHPX only accelerates same-architecture guests, and cannot emulate the OVMF pflash
+            // MMIO that UEFI needs (QEMU GitLab #513). In either case fall through to TCG below.
+            let has_uefi = backend.uefi_code.is_some() || backend.uefi_vars.is_some();
+            if !has_uefi && arch == Arch::host() {
+                push_arg(&mut args, "-accel", "whpx");
+            }
+        }
     }
     push_arg(&mut args, "-accel", "tcg");
 

--- a/src/backend/qemu/mod.rs
+++ b/src/backend/qemu/mod.rs
@@ -128,6 +128,14 @@ impl PortFlock {
             let lock_path = temp_path.join(format!("vci-qemu-port-{port}.lock"));
             let res = FileLock::try_new(lock_path);
             if let Ok(lock) = res {
+                // Optimistic bind probe. Like 99% of the time, a successful TCP bind means the
+                // later QEMU TCP bind will succeed as the ports are rarely in use.
+                // A failed bind means the port is DEFINITELY not available though.
+                // WinNAT/Hyper-V can reserve ports within the PORT_RANGE_START -> PORT_RANGE_END
+                // range.
+                if std::net::TcpListener::bind(("127.0.0.1", port)).is_err() {
+                    continue;
+                }
                 return Ok(PortFlock {
                     lock: Some(lock),
                     port,

--- a/src/backend/qemu/mod.rs
+++ b/src/backend/qemu/mod.rs
@@ -15,6 +15,70 @@ pub mod backend;
 pub mod binaries;
 pub mod kvm;
 
+/// On a Windows host, deciding whether a QEMU image should run natively or inside WSL2 (optionally
+/// with KVM) depends on a few factors:
+/// - **TPM**: Always on WSL2, not avoidable.
+/// - **UEFI**: forces WSL2 ONLY WHEN WSL2 can actually accelerate it. WHPX cannot emulate OVMF
+///   `-pflash` MMIO (QEMU GitLab #513), so a native UEFI VM would have to use TCG. That fallback
+///   is only worth avoiding if KVM acceleration is present. Cross-arch VM is TCG regardless.
+/// - **Legacy BIOS**: Run on the Windows host.
+#[cfg(target_os = "windows")]
+#[must_use]
+pub fn image_runs_in_wsl2(
+    tpm: bool,
+    has_uefi: bool,
+    arch: crate::vm_image::Arch,
+    wsl: Option<&crate::global_paths::WslPaths>,
+) -> bool {
+    use crate::vm_image::Arch;
+
+    if tpm {
+        return true;
+    }
+    if !has_uefi {
+        return false;
+    }
+
+    if arch != Arch::host() {
+        // Cross-arch always runs under TCG so KVM in WSL2 would not help. Keep it on the host.
+        return false;
+    }
+    let Some(wsl) = wsl else {
+        return false;
+    };
+    kvm::check_kvm_access(&HostExecTarget::WSL2(wsl.distro.clone())).is_ok()
+}
+
+/// Resolve the IPv4 address of a WSL2 distro's primary interface, as seen from the Windows host.
+///
+/// When the Windows host drives QEMU inside WSL2, QEMU's `hostfwd` binds the forwarded SSH port
+/// *inside the WSL2 network namespace*, not on the Windows host. Reaching it via `127.0.0.1`
+/// depends on WSL2 localhost forwarding, which is unreliable (and disabled outright in some
+/// configurations). The distro's NAT IP is always directly reachable from the host, so we dial
+/// that instead. The IP is stable for the lifetime of the distro but can change across a
+/// `wsl --shutdown`, so callers resolve it per run rather than caching it on disk.
+#[cfg(target_os = "windows")]
+pub fn wsl_distro_ip(distro: &str) -> anyhow::Result<String> {
+    let output = std::process::Command::new("wsl")
+        .args(["-d", distro, "--", "hostname", "-I"])
+        .output()
+        .context("failed to run `wsl` to resolve the distro IP")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`wsl hostname -I` failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    // `hostname -I` lists every address; the first is the primary eth0 NAT IP.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+        .context("`wsl hostname -I` returned no IP address")
+}
+
 pub struct PortFlock {
     /// Needs to be Option for drop semantics
     lock: Option<FileLock>,

--- a/src/file_lock/flock.c
+++ b/src/file_lock/flock.c
@@ -23,8 +23,15 @@ void unlock_file_native(int fd) { (void)flock(fd, LOCK_UN); }
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+// Turns out Windows LockFileEx strictly locks byte ranges.
+
+#define VCI_LOCK_OFFSET_LOW 0u
+#define VCI_LOCK_OFFSET_HIGH 0x1000000000u
+
 bool try_lock_file_exclusive_native(intptr_t handle) {
     OVERLAPPED overlapped = {0};
+    overlapped.Offset = VCI_LOCK_OFFSET_LOW;
+    overlapped.OffsetHigh = VCI_LOCK_OFFSET_HIGH;
     BOOL result = LockFileEx((HANDLE)handle, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0,
                              1, 0, &overlapped);
     return result != 0;
@@ -32,6 +39,8 @@ bool try_lock_file_exclusive_native(intptr_t handle) {
 
 bool try_lock_file_shared_native(intptr_t handle) {
     OVERLAPPED overlapped = {0};
+    overlapped.Offset = VCI_LOCK_OFFSET_LOW;
+    overlapped.OffsetHigh = VCI_LOCK_OFFSET_HIGH;
     // No LOCKFILE_EXCLUSIVE_LOCK is shared lock
     BOOL result = LockFileEx((HANDLE)handle, LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped);
     return result != 0;
@@ -39,6 +48,8 @@ bool try_lock_file_shared_native(intptr_t handle) {
 
 void unlock_file_native(intptr_t handle) {
     OVERLAPPED overlapped = {0};
+    overlapped.Offset = VCI_LOCK_OFFSET_LOW;
+    overlapped.OffsetHigh = VCI_LOCK_OFFSET_HIGH;
     UnlockFileEx((HANDLE)handle, 0, 1, 0, &overlapped);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,12 +472,22 @@ fn load_image_description(
             .join(", ");
         format!("Failed to load image description '{image_name}' (looked in: {searched})")
     })?;
+
+    #[cfg(target_os = "windows")]
+    let home_wsl_distro = home.wsl_distro.clone();
+
     let vci_path = home.path;
     let contents = std::fs::read_to_string(&vci_path)
         .with_context(|| format!("Failed to read image description at {}", vci_path.display()))?;
     let mut desc: vm_image::ImageDescription = serde_json::from_str(&contents)
         .with_context(|| format!("Failed to parse image description '{image_name}'"))?;
     desc.name = image_name.to_string();
+
+    #[cfg(target_os = "windows")]
+    {
+        desc.wsl_distro = home_wsl_distro;
+    }
+
     Ok(desc)
 }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -24,9 +24,9 @@ use crate::{
     yaml, VciGlobalPaths,
 };
 
-pub const SSH_WAIT_TIMEOUT: u64 = 300;
+pub const SSH_WAIT_TIMEOUT: u64 = 600;
 pub const SSH_POLL_INTERVAL: u64 = 2;
-pub const SSH_AUTH_RETRY_WINDOW: u64 = 30;
+pub const SSH_AUTH_RETRY_WINDOW: u64 = 120;
 /// I don't see why something would take longer than 2 hours realistically.
 /// I have definitely compiled gRPC for over an hour, but 2 hours is some lunacy.
 /// If it does, the user can specify it themselves.
@@ -450,7 +450,7 @@ pub async fn wait_for_ssh(ssh: &SshTarget, timeout_secs: u64) -> Option<u64> {
 
     let timeout = Duration::from_secs(timeout_secs);
     let poll_interval = Duration::from_secs(SSH_POLL_INTERVAL);
-    let connect_timeout = Duration::from_secs(5);
+    let connect_timeout = Duration::from_secs(30);
     let start = Instant::now();
     let addr: std::net::SocketAddr = format!("{}:{}", ssh.ip, ssh.port).parse().unwrap();
 
@@ -460,7 +460,7 @@ pub async fn wait_for_ssh(ssh: &SshTarget, timeout_secs: u64) -> Option<u64> {
         }
         match TcpStream::connect_timeout(&addr, connect_timeout) {
             Ok(stream) => {
-                stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                stream.set_read_timeout(Some(Duration::from_secs(20))).ok();
                 let mut reader = BufReader::new(stream);
                 let mut banner = String::new();
                 if reader.read_line(&mut banner).is_ok() && banner.starts_with("SSH-") {
@@ -476,7 +476,7 @@ pub async fn wait_for_ssh(ssh: &SshTarget, timeout_secs: u64) -> Option<u64> {
 
     let auth_deadline = Instant::now() + Duration::from_secs(SSH_AUTH_RETRY_WINDOW);
     loop {
-        let attempt = tokio::time::timeout(Duration::from_secs(5), connect(ssh)).await;
+        let attempt = tokio::time::timeout(Duration::from_secs(20), connect(ssh)).await;
         if let Ok(Ok(handle)) = attempt {
             drop(handle);
             return Some(start.elapsed().as_secs());

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -113,6 +113,9 @@ impl Job {
                 match tokio::time::timeout(tokio::time::Duration::from_secs(30), enforce_future)
                     .await
                 {
+                    Ok(Ok(res)) if res.exit_code != 0 => {
+                        anyhow::bail!("offline enforcement exited with code {}", res.exit_code)
+                    }
                     Ok(Ok(_)) => {}
                     Ok(Err(e)) => anyhow::bail!("offline enforcement failed: {e}"),
                     Err(_) => {
@@ -418,6 +421,12 @@ impl Job {
                             )
                             .await
                             {
+                                Ok(Ok(res)) if res.exit_code != 0 => {
+                                    anyhow::bail!(
+                                        "offline enforcement exited with code {}",
+                                        res.exit_code
+                                    )
+                                }
                                 Ok(Ok(_)) => {}
                                 Ok(Err(e)) => {
                                     anyhow::bail!("offline enforcement failed: {e}")

--- a/src/vm_image/boot.rs
+++ b/src/vm_image/boot.rs
@@ -239,11 +239,21 @@ fn load_image(name: &str, paths: &VciGlobalPaths) -> Result<ImageDescription, St
             paths.system_home.display()
         )
     })?;
+
+    #[cfg(target_os = "windows")]
+    let home_wsl_distro = home.wsl_distro.clone();
+
     let vci_path = home.path;
     let contents = std::fs::read_to_string(&vci_path)
         .map_err(|e| format!("Failed to read {}: {e}", vci_path.display()))?;
     let mut desc: ImageDescription = serde_json::from_str(&contents)
         .map_err(|e| format!("Failed to parse image description '{name}': {e}"))?;
     desc.name = name.to_string();
+
+    #[cfg(target_os = "windows")]
+    {
+        desc.wsl_distro = home_wsl_distro;
+    }
+
     Ok(desc)
 }

--- a/src/vm_image/import.rs
+++ b/src/vm_image/import.rs
@@ -39,22 +39,19 @@ pub fn run_import(archive_path: &Path, paths: &VciGlobalPaths, system: bool) -> 
 
     warn_if_unsupported_secure_boot(&desc, paths);
 
-    // TPM and UEFI images on Windows MUST run inside of WSL2. WHPX cannot handle either, and QEMU on
-    // a windows host cannot do TPM whatsoever.
     #[cfg(target_os = "windows")]
-    if image_requires_wsl2(&desc) {
+    if image_requires_wsl2(&desc, paths) {
         let Some(wsl) = paths.wsl.as_ref() else {
             let reason = wsl_requirement_reason(&desc);
             anyhow::bail!(
-                "Image '{name}' needs {reason}, which on Windows requires KVM via WSL2 \
-                 (native QEMU/WHPX cannot run TPM or UEFI guests), but no WSL2 distro is \
-                 configured. Set up WSL2 and re-import."
+                "Image '{name}' needs {reason}, which on Windows requires KVM via WSL2, but no \
+                 WSL2 distro is configured. Set up WSL2 and re-import."
             );
         };
         if system {
             anyhow::bail!(
-                "Importing a TPM/UEFI image into WSL2 with --system is not yet supported; \
-                 import it into the user home (omit --system)."
+                "Importing a TPM/UEFI image into WSL2 with --system is not yet supported. \
+                 Import it into the user home (omit --system)."
             );
         }
         return import_into_wsl(archive_path, &mut desc, &name, wsl);
@@ -81,13 +78,17 @@ fn warn_if_unsupported_secure_boot(desc: &ImageDescription, paths: &VciGlobalPat
     }
 
     #[cfg(target_os = "windows")]
-    let exec_target = if qemu.requires_wsl2() {
-        match &paths.wsl {
-            Some(wsl) => crate::vm_image::HostExecTarget::WSL2(wsl.distro.clone()),
-            None => crate::vm_image::HostExecTarget::WindowsNative,
+    let exec_target = {
+        let in_wsl2 = crate::backend::qemu::image_runs_in_wsl2(
+            qemu.tpm,
+            qemu.uefi.is_some(),
+            desc.arch,
+            paths.wsl.as_ref(),
+        );
+        match (&paths.wsl, in_wsl2) {
+            (Some(wsl), true) => crate::vm_image::HostExecTarget::WSL2(wsl.distro.clone()),
+            _ => crate::vm_image::HostExecTarget::WindowsNative,
         }
-    } else {
-        crate::vm_image::HostExecTarget::WindowsNative
     };
     #[cfg(not(target_os = "windows"))]
     let exec_target = {
@@ -290,13 +291,15 @@ fn import_native(
     Ok(())
 }
 
-/// `Some(&WslPaths)` when this image must be imported into WSL2 if a TPM-requiring QEMU image on a
-/// Windows host with a usable WSL2 distro configured.
-/// Whether this image must be staged into WSL2 to be runnable on a Windows host (TPM or UEFI).
-/// See [`crate::vm_image::QemuConfig::requires_wsl2`].
 #[cfg(target_os = "windows")]
-fn image_requires_wsl2(desc: &ImageDescription) -> bool {
-    matches!(&desc.backend, BackendConfig::Qemu(qemu) if qemu.requires_wsl2())
+fn image_requires_wsl2(desc: &ImageDescription, paths: &VciGlobalPaths) -> bool {
+    matches!(&desc.backend, BackendConfig::Qemu(qemu)
+    if crate::backend::qemu::image_runs_in_wsl2(
+        qemu.tpm,
+        qemu.uefi.is_some(),
+        desc.arch,
+        paths.wsl.as_ref(),
+    ))
 }
 
 /// Human-readable reason an image needs WSL2, for error messages.

--- a/src/vm_image/mod.rs
+++ b/src/vm_image/mod.rs
@@ -112,6 +112,19 @@ pub enum Arch {
     RISCV64,
 }
 
+impl Arch {
+    /// The architecture of the host running virtci.
+    #[must_use]
+    pub fn host() -> Arch {
+        match std::env::consts::ARCH {
+            "x86_64" => Arch::X64,
+            "aarch64" => Arch::ARM64,
+            "riscv64" => Arch::RISCV64,
+            other => panic!("Unsupported host CPU architecture: {other}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GuestOs {
     Linux,
@@ -155,20 +168,6 @@ pub struct QemuConfig {
     pub nvme: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub readonly_isos: Option<Vec<String>>,
-}
-
-impl QemuConfig {
-    /// On a Windows host, whether this image must run through WSL2 (KVM) rather than native
-    /// QEMU/WHPX. Two independent reasons, both hard limitations of the Windows hypervisor stack:
-    /// - **TPM**: swtpm only exists in the WSL2 distro.
-    /// - **UEFI**: WHPX cannot emulate the OVMF `-pflash` MMIO (QEMU GitLab #513), so *any* UEFI
-    ///   guest fails on native WHPX. Legacy-BIOS guests (`uefi: None`) run fine natively.
-    ///
-    /// On non-Windows hosts this predicate is irrelevant (the exec target is chosen by OS).
-    #[must_use]
-    pub fn requires_wsl2(&self) -> bool {
-        self.tpm || self.uefi.is_some()
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/vm_image/mod.rs
+++ b/src/vm_image/mod.rs
@@ -30,10 +30,12 @@ pub mod setup_tart;
 
 // https://www.linux-kvm.org/downloads/lersek/ovmf-whitepaper-c770f8c.txt
 // https://github.com/tianocore/tianocore.github.io/wiki/How-to-run-OVMF
-// The UEFI firmware can be split into two sections
+// The UEFI firmware can be split into two sections.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UefiSplit {
+    /// Set to "auto" to force discovery in system directories.
     pub code: String,
+    /// Set to "auto" to force discovery in system directories.
     pub vars: String,
 }
 

--- a/src/vm_image/setup_qemu.rs
+++ b/src/vm_image/setup_qemu.rs
@@ -629,6 +629,11 @@ pub fn find_uefi_firmware(arch: Arch) -> Option<(String, String)> {
                 "/opt/homebrew/share/qemu/edk2-riscv-code.fd",
                 "/opt/homebrew/share/qemu/edk2-riscv-vars.fd",
             ),
+            // Windows
+            (
+                "C:\\Program Files\\qemu\\share\\edk2-riscv-code.fd",
+                "C:\\Program Files\\qemu\\share\\edk2-riscv-vars.fd",
+            ),
         ],
     };
 

--- a/src/vm_image/setup_qemu.rs
+++ b/src/vm_image/setup_qemu.rs
@@ -40,17 +40,20 @@ pub fn run_interactive_setup(paths: &VciGlobalPaths, system: bool) -> anyhow::Re
     let (tpm, nvme, cpu_model, additional_drives, additional_devices, readonly_isos) =
         prompt_advanced_options(guest_os, arch)?;
 
-    // On Windows, TPM or UEFI images must run via WSL2/KVM — native WHPX has no swtpm and cannot
-    // emulate the OVMF pflash MMIO (QEMU GitLab #513). BIOS, non-TPM images run natively.
     #[cfg(target_os = "windows")]
-    let needs_wsl2 = tpm || uefi.is_some();
+    let needs_wsl2 =
+        crate::backend::qemu::image_runs_in_wsl2(tpm, uefi.is_some(), arch, paths.wsl.as_ref());
+    #[cfg(target_os = "windows")]
+    if uefi.is_some() && !tpm && !needs_wsl2 {
+        eprintln!("UEFI image will run natively on the Windows host under TCG emulation.");
+    }
 
     #[cfg(target_os = "windows")]
     let wsl_distro: Option<String> = if needs_wsl2 {
         match &paths.wsl {
             None => anyhow::bail!(
-                "A WSL2 distro is required for TPM or UEFI VMs on Windows \
-                 (native QEMU/WHPX cannot run them)."
+                "A WSL2 distro is required for TPM VMs on Windows \
+                 (swtpm is unavailable on the Windows host)."
             ),
             Some(wsl_paths) => Some(wsl_paths.distro.clone()),
         }


### PR DESCRIPTION
- Run UEFI VMs on Windows Host.
- Fixed cannot SSH to WSL2 VM from Windows Host.
- Fixed terminal formatting.
- Fixed `virtci active` and `virtci shell` for Windows Host -> WSL2 VMs.
- Find RISC-V64 UEFI code/vars on Windows hosts.
- Fixed taking a while to find valid Windows TCP forward port for QEMU.
- Fixed workflow run set offline in Windows Host -> WSL2 VMs.